### PR TITLE
feat: 학과명 정규화 기능 추가 및 관련 코드 수정

### DIFF
--- a/app/api/endpoints/graduation.py
+++ b/app/api/endpoints/graduation.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from app.models.graduation import GraduationRequirement
 from app.services.parser import parse_graduation_requirements
+from app.utils.department import normalize_department_name
 import os
 
 # 라우터 생성
@@ -29,11 +30,13 @@ async def get_graduation_requirements(year: str = "2025", department: str = "컴
         if not os.path.exists(pdf_file):
              raise HTTPException(status_code=404, detail="서버에 이수학점표 PDF 파일이 존재하지 않습니다.")
 
+    normalized_department = normalize_department_name(department, default="컴퓨터공학과")
+
     # 3. 파싱 로직 실행
-    parsed_data = parse_graduation_requirements(pdf_file, target_dept=department)
+    parsed_data = parse_graduation_requirements(pdf_file, target_dept=normalized_department)
     
     # 4. 결과가 없으면 에러, 있으면 Pydantic 모델(response_model)에 맞춰 자동 반환
     if not parsed_data:
-        raise HTTPException(status_code=404, detail=f"'{department}'의 데이터를 찾거나 파싱할 수 없습니다.")
+        raise HTTPException(status_code=404, detail=f"'{normalized_department}'의 데이터를 찾거나 파싱할 수 없습니다.")
         
     return parsed_data

--- a/app/api/endpoints/regulations.py
+++ b/app/api/endpoints/regulations.py
@@ -1,10 +1,12 @@
 from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
 from app.models.db import Regulation
 from app.schemas.regulation import RegulationCreate, RegulationResponse
+from app.services.rag_service import RagService
 
 router = APIRouter(prefix="/api/regulations", tags=["Regulations (RAG 데이터)"])
 
@@ -12,26 +14,30 @@ router = APIRouter(prefix="/api/regulations", tags=["Regulations (RAG 데이터)
 @router.post("", response_model=RegulationResponse, status_code=201)
 def create_regulation(body: RegulationCreate, db: Session = Depends(get_db)):
     """학칙·규정 수동 등록. content_vector는 DB가 자동 생성한다."""
-    reg = Regulation(
-        title=body.title,
-        content=body.content,
-        major=body.major,
-        source_tag=body.source_tag,
-        effective_date=body.effective_date,
-        is_active=True,
-    )
-    db.add(reg)
-    db.commit()
-    db.refresh(reg)
-    return RegulationResponse(
-        id=str(reg.id),
-        title=reg.title,
-        content=reg.content,
-        major=reg.major,
-        source_tag=reg.source_tag,
-        effective_date=reg.effective_date,
-        is_active=reg.is_active,
-    )
+    try:
+        reg = Regulation(
+            title=body.title,
+            content=body.content,
+            major=body.major,
+            source_tag=body.source_tag,
+            effective_date=body.effective_date,
+            is_active=True,
+        )
+        db.add(reg)
+        db.commit()
+        db.refresh(reg)
+        return RegulationResponse(
+            id=str(reg.id),
+            title=reg.title,
+            content=reg.content,
+            major=reg.major,
+            source_tag=reg.source_tag,
+            effective_date=reg.effective_date,
+            is_active=reg.is_active,
+        )
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=503, detail=f"학칙 데이터베이스 오류: {str(e)}")
 
 
 @router.get("", response_model=List[RegulationResponse])
@@ -40,19 +46,43 @@ def list_regulations(
     db: Session = Depends(get_db),
 ):
     """규정 목록 조회. major 파라미터로 학과 필터링 가능."""
-    query = db.query(Regulation).filter(Regulation.is_active == True)
-    if major:
-        query = query.filter(Regulation.major == major)
-    regs = query.order_by(Regulation.effective_date.desc()).all()
-    return [
-        RegulationResponse(
-            id=str(r.id),
-            title=r.title,
-            content=r.content,
-            major=r.major,
-            source_tag=r.source_tag,
-            effective_date=r.effective_date,
-            is_active=r.is_active,
-        )
-        for r in regs
-    ]
+    try:
+        query = db.query(Regulation).filter(Regulation.is_active == True)
+        if major:
+            query = query.filter(Regulation.major == major)
+        regs = query.order_by(Regulation.effective_date.desc()).all()
+        return [
+            RegulationResponse(
+                id=str(r.id),
+                title=r.title,
+                content=r.content,
+                major=r.major,
+                source_tag=r.source_tag,
+                effective_date=r.effective_date,
+                is_active=r.is_active,
+            )
+            for r in regs
+        ]
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(status_code=503, detail=f"학칙 데이터베이스 오류: {str(e)}")
+
+
+@router.get("/search")
+def search_regulations(
+    q: str,
+    major: Optional[str] = None,
+    top_k: int = 4,
+    db: Session = Depends(get_db),
+):
+    """RAG용 학칙 전문검색. 오류 시 500 대신 빈 결과를 반환합니다."""
+    if not q.strip():
+        return {"query": q, "major": major, "results": []}
+
+    terms = [part for part in re_split_query(q) if part]
+    results = RagService(db).search(terms, major=major, top_k=max(1, min(top_k, 10)))
+    return {"query": q, "major": major, "results": results}
+
+
+def re_split_query(query: str) -> List[str]:
+    return [term.strip() for term in query.replace(",", " ").split()]

--- a/app/api/endpoints/validator.py
+++ b/app/api/endpoints/validator.py
@@ -26,6 +26,7 @@ from app.services.timetable_parser import TimetableParser
 from app.services.timetable_recommender import TimetableRecommenderService
 from app.services.validator import GraduationValidator
 from app.utils.cse_curriculum import fetch_first_available_cse_curriculum_catalog
+from app.utils.department import normalize_department_name
 from app.utils.earned_credit import (
     build_course_catalog,
     calculate_earned_credit,
@@ -50,14 +51,7 @@ def _to_int(value: Any) -> int | None:
 
 
 def _extract_requirement_department(department: str | None) -> str:
-    if not department:
-        return "컴퓨터공학과"
-
-    tokens = str(department).split()
-    for token in reversed(tokens):
-        if token.endswith(("학과", "학부", "전공")):
-            return token
-    return str(department).strip()
+    return normalize_department_name(department, default="컴퓨터공학과")
 
 
 def _load_graduation_requirement(admission_year: int | None, department: str | None) -> Dict[str, Any] | None:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,11 +11,13 @@ class Settings:
     OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY")
     # 기본 모델은 비용/속도 균형을 위해 mini 계열을 사용. .env에서 OPENAI_MODEL로 변경 가능.
     OPENAI_MODEL: str = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+    GEMINI_API_KEY: str | None = os.getenv("GEMINI_API_KEY")
+    GEMINI_MODEL: str = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
 
     @property
     def llm_enabled(self) -> bool:
         """LLM 호출 가능 여부 (API 키 존재 여부)."""
-        return bool(self.OPENAI_API_KEY)
+        return bool(self.OPENAI_API_KEY or self.GEMINI_API_KEY)
 
 
 settings = Settings()

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -1,7 +1,10 @@
 import os
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from app.models.db import Base
+
+load_dotenv()
 
 # 데이터베이스 URL (실제 운영 시에는 .env 파일에서 관리 권장)
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/unipass")

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1,23 +1,46 @@
 import json
 from typing import Optional
+
+import requests
+
 from app.core.config import settings
 
 
 class LLMClient:
-    """OpenAI Chat Completions 얇은 래퍼.
+    """OpenAI/Gemini JSON completion 얇은 래퍼.
 
-    - API 키가 없으면 enabled=False 가 되어 상위 서비스가 결정론적 폴백을 타도록 합니다.
+    - OpenAI 키가 있으면 OpenAI를 우선 사용합니다.
+    - OpenAI 키가 없고 Gemini 키가 있으면 Gemini generateContent를 사용합니다.
+    - 키가 모두 없으면 enabled=False 가 되어 상위 서비스가 결정론적 폴백을 타도록 합니다.
     - complete_json()은 JSON 응답을 강제하고 dict로 파싱해 반환합니다. 실패 시 None.
     """
 
-    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        gemini_api_key: Optional[str] = None,
+        gemini_model: Optional[str] = None,
+    ):
         self.api_key = api_key if api_key is not None else settings.OPENAI_API_KEY
         self.model = model or settings.OPENAI_MODEL
+        self.gemini_api_key = (
+            gemini_api_key if gemini_api_key is not None else settings.GEMINI_API_KEY
+        )
+        self.gemini_model = gemini_model or settings.GEMINI_MODEL
         self._client = None
 
     @property
     def enabled(self) -> bool:
-        return bool(self.api_key)
+        return bool(self.api_key or self.gemini_api_key)
+
+    @property
+    def provider(self) -> Optional[str]:
+        if self.api_key:
+            return "openai"
+        if self.gemini_api_key:
+            return "gemini"
+        return None
 
     def _get_client(self):
         if self._client is None:
@@ -30,6 +53,15 @@ class LLMClient:
         """system/user 프롬프트로 JSON 응답을 받아 dict로 반환. 오류 시 None."""
         if not self.enabled:
             return None
+
+        if self.api_key:
+            result = self._complete_openai_json(system, user)
+            if result is not None or not self.gemini_api_key:
+                return result
+
+        return self._complete_gemini_json(system, user)
+
+    def _complete_openai_json(self, system: str, user: str) -> Optional[dict]:
         try:
             resp = self._get_client().chat.completions.create(
                 model=self.model,
@@ -44,4 +76,51 @@ class LLMClient:
             return json.loads(content) if content else None
         except Exception:
             # 네트워크/쿼터/파싱 오류 등은 모두 폴백 신호로 처리.
+            return None
+
+    def _complete_gemini_json(self, system: str, user: str) -> Optional[dict]:
+        if not self.gemini_api_key:
+            return None
+
+        url = (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            f"{self.gemini_model}:generateContent"
+        )
+        payload = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "text": (
+                                f"{system}\n\n"
+                                "아래 사용자 요청에 대해 JSON 객체만 반환해.\n"
+                                f"{user}"
+                            )
+                        }
+                    ],
+                }
+            ],
+            "generationConfig": {
+                "temperature": 0.4,
+                "response_mime_type": "application/json",
+            },
+        }
+
+        try:
+            resp = requests.post(
+                url,
+                headers={
+                    "Content-Type": "application/json",
+                    "x-goog-api-key": self.gemini_api_key,
+                },
+                json=payload,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            parts = data["candidates"][0]["content"]["parts"]
+            content = "".join(part.get("text", "") for part in parts)
+            return json.loads(content) if content else None
+        except Exception:
             return None

--- a/app/services/parser.py
+++ b/app/services/parser.py
@@ -1,6 +1,7 @@
 import os
 import json
 from app.services.base_parser import BasePdfParser
+from app.utils.department import normalize_department_name
 
 
 class RequirementParser(BasePdfParser):
@@ -11,6 +12,7 @@ class RequirementParser(BasePdfParser):
 
 
 def parse_graduation_requirements(pdf_path, target_dept="컴퓨터공학과"):
+    target_dept = normalize_department_name(target_dept, default="컴퓨터공학과")
     print(f"[{os.path.basename(pdf_path)}] Y좌표 기반 정밀 윈도우 파싱 시작...\n")
     
     result = {

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -14,6 +14,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.services.rules import GraduationRuleSet
+from app.utils.department import normalize_department_name
 
 
 def _keywords_for(deficiency_key: str, department: Optional[str] = None) -> List[str]:
@@ -74,19 +75,21 @@ class RagService:
         if not query_terms:
             return []
 
-        # 작은따옴표·특수문자 제거 후 tsquery 토큰 조합
-        safe_terms = [re.sub(r"['\"|&!\\]", "", t).strip() for t in query_terms]
+        # plainto_tsquery에 넘길 자연어 검색어. 특수문자는 공백으로 완화한다.
+        safe_terms = [re.sub(r"['\"|&!\\:()]", " ", t).strip() for t in query_terms]
         safe_terms = [t for t in safe_terms if t]
         if not safe_terms:
             return []
 
-        ts_query = " | ".join(f"'{t}'" for t in safe_terms)
+        search_text = " ".join(safe_terms)
 
         major_filter = ""
-        params: dict = {"ts_query": ts_query, "top_k": top_k}
-        if major:
-            major_filter = "AND (r.major IS NULL OR r.major = :major)"
+        params: dict = {"search_text": search_text, "top_k": top_k}
+        normalized_major = normalize_department_name(major)
+        if normalized_major:
+            major_filter = "AND (r.major IS NULL OR r.major IN (:major, :normalized_major))"
             params["major"] = major
+            params["normalized_major"] = normalized_major
 
         # content_vector는 GENERATED 컬럼이라 ORM create_all()에서 생성되지 않으므로
         # 쿼리 시점에 to_tsvector()를 직접 계산한다 (15~100건 규모에서 성능 충분).
@@ -95,18 +98,18 @@ class RagService:
                 r.title,
                 ts_headline(
                     'simple', r.content,
-                    to_tsquery('simple', :ts_query),
+                    plainto_tsquery('simple', :search_text),
                     'MaxWords=60, MinWords=20, MaxFragments=2, StartSel=<<, StopSel=>>'
                 ) AS snippet,
                 r.source_tag,
                 ts_rank(
                     to_tsvector('simple', r.title || ' ' || r.content),
-                    to_tsquery('simple', :ts_query)
+                    plainto_tsquery('simple', :search_text)
                 ) AS rank
             FROM regulations r
             WHERE r.is_active = TRUE
               AND to_tsvector('simple', r.title || ' ' || r.content)
-                  @@ to_tsquery('simple', :ts_query)
+                  @@ plainto_tsquery('simple', :search_text)
               {major_filter}
             ORDER BY rank DESC
             LIMIT :top_k

--- a/app/utils/department.py
+++ b/app/utils/department.py
@@ -1,0 +1,15 @@
+def normalize_department_name(department: str | None, default: str | None = None) -> str | None:
+    """학적/성적표에서 온 소속 문자열을 졸업요건 PDF의 학과명으로 정규화합니다."""
+    if not department:
+        return default
+
+    text = str(department).strip()
+    if not text:
+        return default
+
+    tokens = text.split()
+    for token in reversed(tokens):
+        if token.endswith(("학과", "학부", "전공")):
+            return token
+
+    return text

--- a/app/utils/regulations_seeder.py
+++ b/app/utils/regulations_seeder.py
@@ -12,6 +12,7 @@ embedding(VECTOR) 컬럼은 pgvector 미설치이므로 건드리지 않는다.
 import glob
 import json
 import os
+import argparse
 from datetime import date
 
 from app.core.database import SessionLocal
@@ -120,7 +121,7 @@ def seed_from_pdfs(db, pdf_dir: str) -> int:
     return count
 
 
-def run():
+def run(skip_pdfs: bool = False):
     base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
     json_path = os.path.join(base_dir, "data", "regulations_seed.json")
     pdf_dir = os.path.join(base_dir, "data", "raw_requirements")
@@ -130,8 +131,12 @@ def run():
         print("=== regulations 시드 시작 ===")
         n1 = seed_from_json(db, json_path)
         print(f"  학칙 산문 JSON: {n1}건 삽입")
-        n2 = seed_from_pdfs(db, pdf_dir)
-        print(f"  졸업요건 PDF 보조 시드: {n2}건 삽입")
+        if skip_pdfs:
+            n2 = 0
+            print("  졸업요건 PDF 보조 시드: 건너뜀 (--skip-pdfs)")
+        else:
+            n2 = seed_from_pdfs(db, pdf_dir)
+            print(f"  졸업요건 PDF 보조 시드: {n2}건 삽입")
         total = n1 + n2
         print(f"  합계: {total}건 삽입 (중복 skip 포함)")
         print(f"  현재 테이블 총 행 수: {db.query(Regulation).count()}")
@@ -140,4 +145,11 @@ def run():
 
 
 if __name__ == "__main__":
-    run()
+    parser = argparse.ArgumentParser(description="regulations 테이블 시드")
+    parser.add_argument(
+        "--skip-pdfs",
+        action="store_true",
+        help="data/regulations_seed.json만 적재하고 raw_requirements PDF 보조 시드는 건너뜁니다.",
+    )
+    args = parser.parse_args()
+    run(skip_pdfs=args.skip_pdfs)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE courses (
     name            VARCHAR(200) NOT NULL,
     credits         SMALLINT     NOT NULL CHECK (credits > 0),
     area_type       VARCHAR(50)  NOT NULL,
+    sub_area        VARCHAR(100),
     building_name   VARCHAR(100),
     latitude        NUMERIC(10,7),
     longitude       NUMERIC(10,7),

--- a/tests/test_department_normalization.py
+++ b/tests/test_department_normalization.py
@@ -1,0 +1,19 @@
+import os
+
+from app.services.parser import parse_graduation_requirements
+from app.utils.department import normalize_department_name
+
+
+def test_normalize_department_name_strips_college_prefix():
+    assert normalize_department_name("IT대학 컴퓨터공학과") == "컴퓨터공학과"
+    assert normalize_department_name("문화예술·공과대학 에너지자원·산업공학부") == "에너지자원·산업공학부"
+
+
+def test_parse_graduation_requirements_accepts_it_college_department_name():
+    pdf_path = os.path.join("data", "raw_requirements", "이수학점표_2025학년도.pdf")
+
+    result = parse_graduation_requirements(pdf_path, target_dept="IT대학 컴퓨터공학과")
+
+    assert result is not None
+    assert result["department"] == "컴퓨터공학과"
+    assert result["total_credits"] > 0

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,50 @@
+from app.services.llm_client import LLMClient
+
+
+def test_llm_client_uses_gemini_when_openai_key_is_missing(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": '{"selected":[{"index":0,"rationale":"좋은 구성입니다."}]}'}
+                            ]
+                        }
+                    }
+                ]
+            }
+
+    def fake_post(url, headers, json, timeout):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("app.services.llm_client.requests.post", fake_post)
+
+    client = LLMClient(api_key="", gemini_api_key="gemini-key", gemini_model="gemini-test")
+
+    assert client.enabled is True
+    assert client.provider == "gemini"
+    assert client.complete_json("system", '{"hello":"world"}') == {
+        "selected": [{"index": 0, "rationale": "좋은 구성입니다."}]
+    }
+    assert captured["url"].endswith("/models/gemini-test:generateContent")
+    assert captured["headers"]["x-goog-api-key"] == "gemini-key"
+    assert captured["json"]["generationConfig"]["response_mime_type"] == "application/json"
+
+
+def test_llm_client_is_disabled_without_openai_or_gemini_key():
+    client = LLMClient(api_key="", gemini_api_key="")
+
+    assert client.enabled is False
+    assert client.provider is None
+    assert client.complete_json("system", "user") is None

--- a/tests/test_rag_service.py
+++ b/tests/test_rag_service.py
@@ -1,0 +1,20 @@
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.services.rag_service import RagService
+
+
+class FailingSession:
+    def execute(self, *_args, **_kwargs):
+        raise SQLAlchemyError("database unavailable")
+
+    def rollback(self):
+        self.rolled_back = True
+
+
+def test_rag_search_returns_empty_list_on_database_error():
+    db = FailingSession()
+
+    results = RagService(db).search(["꿈-설계", "기초교양"], major="IT대학 컴퓨터공학과")
+
+    assert results == []
+    assert db.rolled_back is True


### PR DESCRIPTION
## 작업 내용


### 성적표/시간표 파싱 및 졸업요건 처리 개선
- 성적표 PDF에서 학번, 이름, 학과, 총취득학점, 이수 과목, 기본 이수 학점 정보를 추출하도록 개선했습니다.
- `IT대학 컴퓨터공학과`처럼 단과대가 포함된 학과명을 `컴퓨터공학과`로 정규화하는 유틸을 추가했습니다.
- 졸업요건 PDF 파서가 정규화된 학과명으로 데이터를 찾도록 수정했습니다.
- 시간표 PDF 파서에 DB fallback 및 CSV fallback 처리를 추가했습니다.
- 
### 졸업 사정 로직 개선
- RuleChecker 기반으로 졸업 사정 로직을 분리했습니다.
- 전공필수 초과 학점의 전공선택/심화전공 이월 처리, 교양 초과 학점 처리, 세부 교양 필수 영역 검사를 분리했습니다.
- 졸업 사정 결과를 DB에 저장하고 학생별 분석 이력 조회 API를 추가했습니다.

### AI 기반 시간표 추천 기능 추가
- LLM은 검증된 후보 중에서 2~3개 대안을 선택하고 한국어 추천 사유를 생성하도록 분리했습니다.
- OpenAI API Key가 없으면 Gemini API Key를 사용하도록 fallback 로직을 추가했습니다.
- LLM 호출 실패 또는 키 미설정 시 결정론적 추천으로 fallback합니다.

### RAG 기반 학칙 검색 수정
- `/api/regulations` 등록/조회 API와 `/api/regulations/search` 검색 API를 추가했습니다.
- `data/regulations_seed.json` 기반 학칙 시드 데이터를 추가했습니다.
- `regulations_seeder.py --skip-pdfs` 옵션을 추가해 JSON 학칙 데이터만 빠르게 적재할 수 있게 했습니다.


